### PR TITLE
rpi setup playbook

### DIFF
--- a/exercises/e003-rpi/results/Mesiya391/rpi_setup.yml
+++ b/exercises/e003-rpi/results/Mesiya391/rpi_setup.yml
@@ -32,7 +32,7 @@
     become: true
     become_method: sudo
     tasks:
-      - name: generate pasword
+      - name: generate password
         command: pwgen -s -1
         register: new_pass 
 

--- a/exercises/e003-rpi/results/Mesiya391/rpi_setup.yml
+++ b/exercises/e003-rpi/results/Mesiya391/rpi_setup.yml
@@ -1,0 +1,42 @@
+---
+  - name: rpi setup
+    hosts: RPIs
+    become: true
+    become_method: sudo
+    vars:
+      software_list:
+        - bc
+        - curl
+        - dnsutils
+        - man 
+        - mtr-tiny
+        - netcat
+        - rdate
+        - rsync
+        - screen
+        - socat
+        - sudo
+        - tcpdump
+        - tmux
+        - wget
+        - nload
+        - pwgen
+    tasks:
+      - name: install required tools
+        apt: 
+          name: "{{software_list}}" 
+       
+
+  - name: change pi pass
+    hosts: RPIs
+    become: true
+    become_method: sudo
+    tasks:
+      - name: generate pasword
+        command: pwgen -s -1
+        register: new_pass 
+
+      - name: change pi pass
+        user:
+          name: pi
+          password: "{{ new_pass.stdout | password_hash('sha512') }}"


### PR DESCRIPTION
In order to execute the below playbook please use: ansible-playbook [path to playbook]. The host configuration is stored in text file which is then assigned in ansible.cfg as the default configuration